### PR TITLE
Implement Infosimples search integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const VehicleRegistration = lazy(() => import("./pages/vehicles/VehicleRegistrat
 const ProcessManagement = lazy(() => import("./pages/processes/ProcessManagement"));
 const ClientProfile = lazy(() => import("./pages/clients/ClientProfile"));
 const Settings = lazy(() => import("./pages/settings/Settings"));
+const InfosimplesSearch = lazy(() => import("./pages/search/InfosimplesSearch"));
 
 const PageLoader = () => (
   <div className="flex items-center justify-center min-h-[50vh]">
@@ -102,6 +103,8 @@ const App = () => (
           <Route path="/import" element={<Layout userRole="admin"><BulkImportForm /></Layout>} />
           
           <Route path="/search" element={<Layout userRole="admin"><AdvancedSearch /></Layout>} />
+
+          <Route path="/search/infosimples" element={<Layout userRole="admin"><InfosimplesSearch /></Layout>} />
           
           <Route path="/crm" element={<Layout userRole="admin"><LeadManagement /></Layout>} />
           

--- a/src/components/infosimples/CnhSearchForm.tsx
+++ b/src/components/infosimples/CnhSearchForm.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/components/ui/use-toast";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import * as InfosimplesService from "@/services/api/infosimples-service";
+import { Search } from "lucide-react";
+
+export default function CnhSearchForm() {
+  const { user } = useSupabaseAuth();
+  const { toast } = useToast();
+  const [cnh, setCnh] = useState("");
+  const [birthDate, setBirthDate] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any | null>(null);
+
+  const formatCnh = (value: string) => value.replace(/\D/g, "").slice(0, 11);
+
+  const startSearch = async () => {
+    if (!user) {
+      toast({ title: "Erro", description: "Usuário não autenticado", variant: "destructive" });
+      return;
+    }
+    if (cnh.length !== 11 || !birthDate) {
+      toast({ title: "Dados inválidos", variant: "destructive" });
+      return;
+    }
+    try {
+      setLoading(true);
+      setResult(null);
+      const { requestId, protocol } = await InfosimplesService.runCNHSearch(cnh, birthDate, user.id);
+      const poll = setInterval(async () => {
+        try {
+          const data = await InfosimplesService.pollResult(requestId, protocol);
+          if (data && !(data as any).status) {
+            clearInterval(poll);
+            setResult(data);
+            setLoading(false);
+          }
+        } catch (err: any) {
+          clearInterval(poll);
+          setLoading(false);
+          toast({ title: "Erro", description: err.message, variant: "destructive" });
+        }
+      }, 5000);
+    } catch (err: any) {
+      setLoading(false);
+      toast({ title: "Erro", description: err.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Consulta por CNH</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-2 max-w-sm md:grid-cols-2">
+          <Input
+            value={cnh}
+            onChange={(e) => setCnh(formatCnh(e.target.value))}
+            placeholder="Número da CNH"
+          />
+          <Input type="date" value={birthDate} onChange={(e) => setBirthDate(e.target.value)} />
+        </div>
+        <Button onClick={startSearch} disabled={loading || cnh.length !== 11 || !birthDate} className="mt-2">
+          {loading ? <LoadingSpinner size="sm" /> : <Search className="h-4 w-4" />}
+        </Button>
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <LoadingSpinner size="sm" />
+            <span>Consultando...</span>
+          </div>
+        )}
+        {result && (
+          <pre className="whitespace-pre-wrap break-all rounded bg-muted p-4 text-sm">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/infosimples/PlateSearchForm.tsx
+++ b/src/components/infosimples/PlateSearchForm.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/components/ui/use-toast";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import * as InfosimplesService from "@/services/api/infosimples-service";
+import { Search } from "lucide-react";
+
+function formatPlate(value: string) {
+  const cleaned = value.toUpperCase().replace(/[^A-Z0-9]/g, "");
+  let formatted = cleaned;
+  if (formatted.length > 3) {
+    formatted = `${formatted.slice(0, 3)}-${formatted.slice(3)}`;
+  }
+  return formatted.slice(0, 8);
+}
+
+export default function PlateSearchForm() {
+  const { user } = useSupabaseAuth();
+  const { toast } = useToast();
+  const [plate, setPlate] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPlate(formatPlate(e.target.value));
+  };
+
+  const startSearch = async () => {
+    if (!user) {
+      toast({ title: "Erro", description: "Usuário não autenticado", variant: "destructive" });
+      return;
+    }
+    if (!plate || plate.length < 7) {
+      toast({ title: "Placa inválida", variant: "destructive" });
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setResult(null);
+      const cleaned = plate.replace(/-/g, "");
+      const { requestId, protocol } = await InfosimplesService.runPlateSearch(cleaned, user.id);
+      const poll = setInterval(async () => {
+        try {
+          const data = await InfosimplesService.pollResult(requestId, protocol);
+          if (data && !(data as any).status) {
+            clearInterval(poll);
+            setResult(data);
+            setLoading(false);
+          }
+        } catch (err: any) {
+          clearInterval(poll);
+          setLoading(false);
+          toast({ title: "Erro", description: err.message, variant: "destructive" });
+        }
+      }, 5000);
+    } catch (err: any) {
+      setLoading(false);
+      toast({ title: "Erro", description: err.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Consulta por Placa</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex gap-2 max-w-xs">
+          <Input value={plate} onChange={handleChange} placeholder="AAA-0A00" />
+          <Button onClick={startSearch} disabled={!plate || loading}>
+            {loading ? <LoadingSpinner size="sm" /> : <Search className="h-4 w-4" />}
+          </Button>
+        </div>
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <LoadingSpinner size="sm" />
+            <span>Consultando...</span>
+          </div>
+        )}
+        {result && (
+          <pre className="whitespace-pre-wrap break-all rounded bg-muted p-4 text-sm">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/infosimples/RenavamSearchForm.tsx
+++ b/src/components/infosimples/RenavamSearchForm.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/components/ui/use-toast";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import * as InfosimplesService from "@/services/api/infosimples-service";
+import { Search } from "lucide-react";
+
+export default function RenavamSearchForm() {
+  const { user } = useSupabaseAuth();
+  const { toast } = useToast();
+  const [renavam, setRenavam] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<any | null>(null);
+
+  const formatRenavam = (val: string) => val.replace(/\D/g, "").slice(0, 11);
+
+  const startSearch = async () => {
+    if (!user) {
+      toast({ title: "Erro", description: "Usuário não autenticado", variant: "destructive" });
+      return;
+    }
+    if (renavam.length < 9) {
+      toast({ title: "RENAVAM inválido", variant: "destructive" });
+      return;
+    }
+    try {
+      setLoading(true);
+      setResult(null);
+      const { requestId, protocol } = await InfosimplesService.runRenavamSearch(renavam, user.id);
+      const poll = setInterval(async () => {
+        try {
+          const data = await InfosimplesService.pollResult(requestId, protocol);
+          if (data && !(data as any).status) {
+            clearInterval(poll);
+            setResult(data);
+            setLoading(false);
+          }
+        } catch (err: any) {
+          clearInterval(poll);
+          setLoading(false);
+          toast({ title: "Erro", description: err.message, variant: "destructive" });
+        }
+      }, 5000);
+    } catch (err: any) {
+      setLoading(false);
+      toast({ title: "Erro", description: err.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Consulta por RENAVAM</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex gap-2 max-w-xs">
+          <Input
+            value={renavam}
+            onChange={(e) => setRenavam(formatRenavam(e.target.value))}
+            placeholder="Digite o RENAVAM"
+          />
+          <Button onClick={startSearch} disabled={!renavam || loading}>
+            {loading ? <LoadingSpinner size="sm" /> : <Search className="h-4 w-4" />}
+          </Button>
+        </div>
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <LoadingSpinner size="sm" />
+            <span>Consultando...</span>
+          </div>
+        )}
+        {result && (
+          <pre className="whitespace-pre-wrap break-all rounded bg-muted p-4 text-sm">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
+import { FileSearch } from "lucide-react";
 
 // Import components
 import SidebarUser from "./sidebar/SidebarUser";
@@ -24,7 +25,14 @@ const Sidebar = ({ isOpen, userRole = "admin" }: SidebarProps) => {
   };
 
   // Get menu items based on user role
-  const menuItems = getRoleMenuItems(userRole);
+  const menuItems = [
+    ...getRoleMenuItems(userRole),
+    {
+      title: "Consultas Infosimples",
+      href: "/search/infosimples",
+      icon: FileSearch,
+    },
+  ];
 
   return (
     <aside

--- a/src/pages/search/InfosimplesSearch.tsx
+++ b/src/pages/search/InfosimplesSearch.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import PlateSearchForm from "@/components/infosimples/PlateSearchForm";
+import RenavamSearchForm from "@/components/infosimples/RenavamSearchForm";
+import CnhSearchForm from "@/components/infosimples/CnhSearchForm";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function InfosimplesSearch() {
+  const [tab, setTab] = useState("plate");
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Consultas Infosimples</h1>
+        <p className="text-muted-foreground">Realize consultas de veículos e condutores utilizando a API Infosimples.</p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Nova Consulta</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Tabs value={tab} onValueChange={setTab} className="space-y-4">
+            <TabsList className="grid w-full grid-cols-3">
+              <TabsTrigger value="plate">Placa</TabsTrigger>
+              <TabsTrigger value="renavam">RENAVAM</TabsTrigger>
+              <TabsTrigger value="cnh">CNH</TabsTrigger>
+            </TabsList>
+            <TabsContent value="plate">
+              <PlateSearchForm />
+            </TabsContent>
+            <TabsContent value="renavam">
+              <RenavamSearchForm />
+            </TabsContent>
+            <TabsContent value="cnh">
+              <CnhSearchForm />
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/services/api/infosimples-api.ts
+++ b/src/services/api/infosimples-api.ts
@@ -4,8 +4,8 @@ import { toast } from "@/components/ui/sonner";
 const INFOSIMPLES_API_BASE_URL = "https://api.infosimples.com/api/v2";
 
 // Store API credentials securely - in production, these should come from environment variables or user input
-let token = "";
-let email = "";
+let token = import.meta.env.VITE_INFOSIMPLES_TOKEN || "";
+let email = import.meta.env.VITE_INFOSIMPLES_EMAIL || "";
 
 export const setInfosimplesCredentials = (userEmail: string, apiToken: string) => {
   email = userEmail;

--- a/src/services/api/infosimples-service.ts
+++ b/src/services/api/infosimples-service.ts
@@ -1,0 +1,110 @@
+import { supabase } from "@/integrations/supabase/client";
+import {
+  searchVehicleByPlate,
+  searchVehicleByRenavam,
+  searchDriverByCNH,
+  getConsultationStatus,
+  getConsultationResult,
+} from "./infosimples-api";
+
+export async function runPlateSearch(plate: string, userId: string) {
+  const { data, error } = await supabase
+    .from("infosimples_requests")
+    .insert({
+      user_id: userId,
+      search_type: "plate",
+      search_query: plate,
+      status: "pending",
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || "Failed to create request");
+  }
+
+  const response = await searchVehicleByPlate(plate);
+  const protocol = (response as any).protocolo || (response as any).protocol;
+
+  await supabase
+    .from("infosimples_requests")
+    .update({ protocol, status: "running" })
+    .eq("id", data.id);
+
+  return { requestId: data.id, protocol };
+}
+
+export async function runRenavamSearch(renavam: string, userId: string) {
+  const { data, error } = await supabase
+    .from("infosimples_requests")
+    .insert({
+      user_id: userId,
+      search_type: "renavam",
+      search_query: renavam,
+      status: "pending",
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || "Failed to create request");
+  }
+
+  const response = await searchVehicleByRenavam(renavam);
+  const protocol = (response as any).protocolo || (response as any).protocol;
+
+  await supabase
+    .from("infosimples_requests")
+    .update({ protocol, status: "running" })
+    .eq("id", data.id);
+
+  return { requestId: data.id, protocol };
+}
+
+export async function runCNHSearch(cnh: string, birthDate: string, userId: string) {
+  const { data, error } = await supabase
+    .from("infosimples_requests")
+    .insert({
+      user_id: userId,
+      search_type: "cnh",
+      search_query: cnh,
+      status: "pending",
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message || "Failed to create request");
+  }
+
+  const response = await searchDriverByCNH(cnh, birthDate);
+  const protocol = (response as any).protocolo || (response as any).protocol;
+
+  await supabase
+    .from("infosimples_requests")
+    .update({ protocol, status: "running" })
+    .eq("id", data.id);
+
+  return { requestId: data.id, protocol };
+}
+
+export async function pollResult(requestId: string, protocol: string) {
+  const status = await getConsultationStatus(protocol);
+  if ((status as any).status !== "concluido") {
+    return status;
+  }
+
+  const result = await getConsultationResult(protocol);
+
+  await supabase.from("infosimples_results").insert({
+    request_id: requestId,
+    result_data: result,
+  });
+
+  await supabase
+    .from("infosimples_requests")
+    .update({ status: "completed" })
+    .eq("id", requestId);
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- enable Infosimples API credentials from environment variables
- add service layer to handle API requests and Supabase persistence
- create plate, CNH and RENAVAM search forms
- build page with tabs for Infosimples searches
- expose route and sidebar entry for Infosimples searches

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c7172b9288321bad2d30d2a1e024d